### PR TITLE
Allow global pipenv installation + let user install venv manually

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -7,7 +7,11 @@ source "$RTX_PLUGIN_PATH/bin/utils.sh"
 
 setup_pipenv() {
     VIRTUAL_ENV=$(pipenv_venv)
-    if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then
+    if [[ -z $VIRTUAL_ENV ]]; then
+        return
+    fi
+
+    if [[ ! -d $VIRTUAL_ENV ]]; then
         "$(pipenv_bin)" install --dev
         VIRTUAL_ENV=$(pipenv --venv)
     fi

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -8,12 +8,15 @@ source "$RTX_PLUGIN_PATH/bin/utils.sh"
 setup_pipenv() {
     VIRTUAL_ENV=$(pipenv_venv)
     if [[ -z $VIRTUAL_ENV ]]; then
+        # in a directory without a Pipfile
         return
     fi
 
     if [[ ! -d $VIRTUAL_ENV ]]; then
-        "$(pipenv_bin)" install --dev
-        VIRTUAL_ENV=$(pipenv --venv)
+        # in a directory with a Pipfile but no virtualenv
+        echoerr "rtx-pipenv: $VIRTUAL_ENV"
+        echoerr "rtx-pipenv: install pipenv virtualenv manually 'pipenv install ...'"
+        return
     fi
     PIPENV_ACTIVE=1
     export VIRTUAL_ENV PIPENV_ACTIVE

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -21,5 +21,7 @@ pipenv_venv() {
         echoerr "rtx-pipenv: no Pipfile found at $pipfile"
         exit 1
     fi
-    "$(pipenv_bin)" --venv 2>/dev/null
+
+    pipenv_venv_dir="$("$(pipenv_bin)" --venv 2>/dev/null)"
+    echo "${pipenv_venv_dir:-pipfile found without venv}"
 }


### PR DESCRIPTION
## Problem
1. Currently, if you have `python` and `pipenv` in `~/.config/rtx/config.toml` this plugin will create a pipenv venv in every directory you navigate to.

2. If you configure your local `.rtx.toml` according to the readme, the automatic pipenv venv installation would pickup the globally available python, not the local one (I guess due to the parallel execution by rtx).

## Suggested Fix
1. skip pipenv setup when no Pipfile is found in current directory
2. let the user install the pipenv venv manually after rtx has done its thing